### PR TITLE
Исправление физики закрытия скролл модалки

### DIFF
--- a/lib/src/feature/more/presentation/modals/faq_modal.dart
+++ b/lib/src/feature/more/presentation/modals/faq_modal.dart
@@ -4,7 +4,9 @@ import 'package:frifri/src/core/ui-kit/modals/base_modal.dart';
 import 'package:frifri/src/core/ui-kit/modals/default_modal_header.dart';
 
 class FaqModal extends BottomSheetStatelessModalBase {
-  const FaqModal({super.key});
+  const FaqModal({super.key, required this.scrollController});
+
+  final ScrollController scrollController;
 
   static const TextStyle _headerTextStyle = TextStyle(
     fontSize: 16.0,
@@ -38,6 +40,7 @@ class FaqModal extends BottomSheetStatelessModalBase {
           vertical: 24.0,
         ),
         child: ListView(
+          controller: scrollController,
           children: [
             SizedBox(
               height: 12,

--- a/lib/src/feature/more/presentation/modals/help_modal.dart
+++ b/lib/src/feature/more/presentation/modals/help_modal.dart
@@ -1,6 +1,4 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 import 'package:frifri/src/core/ui-kit/modals/base_modal.dart';
 import 'package:frifri/src/core/ui-kit/modals/default_modal_header.dart';
@@ -38,7 +36,17 @@ class HelpModal extends BottomSheetStatelessModalBase {
               showModalBottomSheet(
                 context: context,
                 isScrollControlled: true,
-                builder: (context) => FaqModal(),
+                builder: (context) => DraggableScrollableSheet(
+                  expand: false,
+                  // Здесь передаём контроллер в модалку
+                  // чтобы скролл внутри модалки позволял её закрыть
+                  initialChildSize: 0.9,
+                  minChildSize: 0.85,
+                  maxChildSize: 0.9,
+                  builder: (context, controller) => FaqModal(
+                    scrollController: controller,
+                  ),
+                ),
               );
             },
             child: ListTile(
@@ -57,7 +65,17 @@ class HelpModal extends BottomSheetStatelessModalBase {
               showModalBottomSheet(
                 context: context,
                 isScrollControlled: true,
-                builder: (context) => FaqModal(),
+                builder: (context) => DraggableScrollableSheet(
+                  expand: false,
+                  // Здесь передаём контроллер в модалку
+                  // чтобы скролл внутри модалки позволял её закрыть
+                  initialChildSize: 0.9,
+                  minChildSize: 0.8,
+                  maxChildSize: 0.9,
+                  builder: (context, controller) => FaqModal(
+                    scrollController: controller,
+                  ),
+                ),
               );
             },
             child: ListTile(
@@ -76,7 +94,17 @@ class HelpModal extends BottomSheetStatelessModalBase {
               showModalBottomSheet(
                 context: context,
                 isScrollControlled: true,
-                builder: (context) => FaqModal(),
+                builder: (context) => DraggableScrollableSheet(
+                  expand: false,
+                  // Здесь передаём контроллер в модалку
+                  // чтобы скролл внутри модалки позволял её закрыть
+                  initialChildSize: 0.9,
+                  minChildSize: 0.8,
+                  maxChildSize: 0.9,
+                  builder: (context, controller) => FaqModal(
+                    scrollController: controller,
+                  ),
+                ),
               );
             },
             child: ListTile(


### PR DESCRIPTION
Сделал возможным закрытие модалки с помощью скролла по её контенту, применив DraggableScrollableSheet из статьи на SO:

https://stackoverflow.com/questions/73733155/modalbottomsheet-listview-how-to-sync-scroll